### PR TITLE
fix minor problems

### DIFF
--- a/hysteria2/client.go
+++ b/hysteria2/client.go
@@ -252,7 +252,8 @@ func (c *clientQUICConnection) closeWithError(err error) {
 	c.closeOnce.Do(func() {
 		c.connErr = err
 		close(c.connDone)
-		c.quicConn.CloseWithError(0, "")
+		_ = c.quicConn.CloseWithError(0, "")
+		_ = c.rawConn.Close()
 	})
 }
 

--- a/hysteria2/packet.go
+++ b/hysteria2/packet.go
@@ -37,7 +37,7 @@ func allocMessage() *udpMessage {
 func releaseMessages(messages []*udpMessage) {
 	for _, message := range messages {
 		if message != nil {
-			message.release()
+			message.releaseMessage()
 		}
 	}
 }

--- a/tuic/client.go
+++ b/tuic/client.go
@@ -194,7 +194,7 @@ func (c *Client) ListenPacket(ctx context.Context) (net.PacketConn, error) {
 		return nil, err
 	}
 	var sessionID uint16
-	clientPacketConn := newUDPPacketConn(ctx, conn.quicConn, c.udpStream, false, func() {
+	clientPacketConn := newUDPPacketConn(c.ctx, conn.quicConn, c.udpStream, false, func() {
 		conn.udpAccess.Lock()
 		delete(conn.udpConnMap, sessionID)
 		conn.udpAccess.Unlock()

--- a/tuic/packet.go
+++ b/tuic/packet.go
@@ -36,7 +36,7 @@ func allocMessage() *udpMessage {
 func releaseMessages(messages []*udpMessage) {
 	for _, message := range messages {
 		if message != nil {
-			message.release()
+			message.releaseMessage()
 		}
 	}
 }


### PR DESCRIPTION
hysteria client now closes the underlying udp socket too, releaseMessages also releases the buffers back to the pool as well, and tuic's ListenPacket now uses the connection's context.