### PR TITLE
Fix quic stream close logic

### DIFF
--- a/hysteria/client.go
+++ b/hysteria/client.go
@@ -360,6 +360,8 @@ func (c *clientConn) RemoteAddr() net.Addr {
 }
 
 func (c *clientConn) Close() error {
-	c.Stream.CancelRead(0)
+	if !c.NeedHandshake() {
+		c.Stream.CancelRead(0)
+	}
 	return c.Stream.Close()
 }

--- a/hysteria2/client.go
+++ b/hysteria2/client.go
@@ -320,6 +320,8 @@ func (c *clientConn) RemoteAddr() net.Addr {
 }
 
 func (c *clientConn) Close() error {
-	c.Stream.CancelRead(0)
+	if !c.NeedHandshake() {
+		c.Stream.CancelRead(0)
+	}
 	return c.Stream.Close()
 }

--- a/tuic/client.go
+++ b/tuic/client.go
@@ -290,7 +290,9 @@ func (c *clientConn) Write(b []byte) (n int, err error) {
 }
 
 func (c *clientConn) Close() error {
-	c.Stream.CancelRead(0)
+	if !c.NeedHandshake() {
+		c.Stream.CancelRead(0)
+	}
 	return c.Stream.Close()
 }
 


### PR DESCRIPTION
when a tuic client requests a stream and then closes it without sending any data, the cancelRead frame is sent and thus the stream is accepted on the server side. The server's `handleStream` is then stuck trying to read 2 bytes from the stream, and since the stream has no timeout and is never closed, their goroutines can pile up on long running clients. This PR addresses this issue by sending the tuic request immediately after the stream is requested, and so if the client closes the stream without sending any data, the server will also close this as expected.