### PR TITLE
fix: should use sessionID to refrag udp packet

### DIFF
--- a/hysteria2/packet.go
+++ b/hysteria2/packet.go
@@ -54,10 +54,9 @@ type udpMessage struct {
 }
 
 func (m *udpMessage) release() {
-	if !m.referenced {
-		return
+	if m.referenced {
+		*m = udpMessage{}
 	}
-	*m = udpMessage{}
 	udpMessagePool.Put(m)
 }
 
@@ -309,15 +308,15 @@ func (c *udpPacketConn) SetWriteDeadline(t time.Time) error {
 }
 
 type udpDefragger struct {
-	packetMap *cache.LruCache[uint16, *packetItem]
+	packetMap *cache.LruCache[uint32, *packetItem]
 }
 
 func newUDPDefragger() *udpDefragger {
 	return &udpDefragger{
 		packetMap: cache.New(
-			cache.WithAge[uint16, *packetItem](10),
-			cache.WithUpdateAgeOnGet[uint16, *packetItem](),
-			cache.WithEvict[uint16, *packetItem](func(key uint16, value *packetItem) {
+			cache.WithAge[uint32, *packetItem](10),
+			cache.WithUpdateAgeOnGet[uint32, *packetItem](),
+			cache.WithEvict[uint32, *packetItem](func(key uint32, value *packetItem) {
 				releaseMessages(value.messages)
 			}),
 		),
@@ -337,7 +336,7 @@ func (d *udpDefragger) feed(m *udpMessage) *udpMessage {
 	if m.fragmentID >= m.fragmentTotal {
 		return nil
 	}
-	item, _ := d.packetMap.LoadOrStore(m.packetID, newPacketItem)
+	item, _ := d.packetMap.LoadOrStore(m.sessionID, newPacketItem)
 	item.access.Lock()
 	defer item.access.Unlock()
 	if int(m.fragmentTotal) != len(item.messages) {

--- a/tuic/packet.go
+++ b/tuic/packet.go
@@ -53,10 +53,9 @@ type udpMessage struct {
 }
 
 func (m *udpMessage) release() {
-	if !m.referenced {
-		return
+	if m.referenced {
+		*m = udpMessage{}
 	}
-	*m = udpMessage{}
 	udpMessagePool.Put(m)
 }
 
@@ -400,7 +399,7 @@ func (d *udpDefragger) feed(m *udpMessage) *udpMessage {
 	if m.fragmentID >= m.fragmentTotal {
 		return nil
 	}
-	item, _ := d.packetMap.LoadOrStore(m.packetID, newPacketItem)
+	item, _ := d.packetMap.LoadOrStore(m.sessionID, newPacketItem)
 	item.access.Lock()
 	defer item.access.Unlock()
 	if int(m.fragmentTotal) != len(item.messages) {


### PR DESCRIPTION
Any udp packet larger than 1197 will always be dropped on any quic based outbound.

Updates SagerNet/sing-box#1650