### PR TITLE
fix tuic implementation

### DIFF
--- a/tuic/packet.go
+++ b/tuic/packet.go
@@ -83,7 +83,7 @@ func (m *udpMessage) pack() *buf.Buffer {
 }
 
 func (m *udpMessage) headerSize() int {
-	return 10 + AddressSerializer.AddrPortLen(m.destination)
+	return 12 + AddressSerializer.AddrPortLen(m.destination)
 }
 
 func fragUDPMessage(message *udpMessage, maxPacketSize int) []*udpMessage {


### PR DESCRIPTION
- `headerSize` of `udpMessage` is incorrect.
- Server-to-client `CommandHeartbeat` does not exist. The specification and the original server implementation don't have this, and the original client implementation warns about this unknown command.
- Let the client ignore unknown commands. This is the behavior of the original client implementation, and it is also needed for those sing-quic servers sending `CommandHeartbeat` to clients.
- Client should not loopMessages if `udpStream` is enabled, and should not loopUniStreams if `udpStream` is disabled.

P.S. There is a Hysteria2 HTTP/3 issue that `http3.ConfigureTLSConfig` returns a new `tls.Config` rather than modifying the given `tlsConfig`. https://github.com/SagerNet/sing-quic/blob/00a55617c0fb7747c80ada97560b74c6a5c25dfc/quic.go#L117 Fixing this may need new interfaces.